### PR TITLE
OSX 109 fixes

### DIFF
--- a/src/mym.cpp
+++ b/src/mym.cpp
@@ -163,7 +163,7 @@ static void fancyprint(MYSQL_RES*res) {
     char**fmt = (char**) mxMalloc(nfield*sizeof(char*));
     for (ulong j = 0; j<nfield; j++) {
         fmt[j] = (char*) mxCalloc(10, sizeof(char));
-        sprintf(fmt[j], "  %%-%lu ", len[j]);
+        sprintf(fmt[j], "  %%-%lus ", len[j]);
     }
     /************************************************************************/
     //  Now print the actual data


### PR DESCRIPTION
mym doesn't compile (for me) on OSX 10.9. These two
fixes are required on the mym side.

I also had to follow some of the instructions from here:
http://stackoverflow.com/questions/19773916/compiling-mexopencv-in-os-x-10-9-with-xcode-5-and-matlab-r2013b
specifically updating the 10.7 in mexopts to 10.9 and replacing ""-lstdc++" with "-lc++". 
These are problems matlab problems though (and I'm running 2013a so might
be resolved now).
